### PR TITLE
Change sign in duration to 50

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -25,7 +25,7 @@ if sentry_config:
                   traces_sample_rate=sentry_config.get('traces_sample_rate', 0.1))
 
 
-SIGNIN_DURATION_IN_DAYS = 30
+SIGNIN_DURATION_IN_DAYS = 50
 
 
 def init_app_without_routes(disable_csrf=False):


### PR DESCRIPTION
Changes sign in duration in 50 because customer complained that 30 days is too short.